### PR TITLE
use string value when encoding enums

### DIFF
--- a/tests/test_decoder.nim
+++ b/tests/test_decoder.nim
@@ -349,6 +349,9 @@ suite "test decoder":
       Toml.decode("v = \"aaa\"\n", EnumTestZ, "v") == z1
       Toml.decode("v = \"bbb\"\n", EnumTestZ, "v") == z2
       Toml.decode("v = \"ccc\"\n", EnumTestZ, "v") == z3
+      Toml.decode("v = \'aaa\'\n", EnumTestZ, "v") == z1
+      Toml.decode("v = \'bbb\'\n", EnumTestZ, "v") == z2
+      Toml.decode("v = \'ccc\'\n", EnumTestZ, "v") == z3
     expect TomlError:
       discard Toml.decode("v = 0\n", EnumTestZ, "v")
     expect TomlError:

--- a/tests/test_decoder.nim
+++ b/tests/test_decoder.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  std/[os, options, tables],
+  std/[os, options, strutils, tables],
   unittest2,
   ../toml_serialization,
   ../toml_serialization/[lexer, value_ops]
@@ -58,6 +58,53 @@ type
 proc readValue(r: var TomlReader, table: var Table[string, int]) =
   parseTable(r, key):
     table[key] = r.parseInt(int)
+
+when (NimMajor, NimMinor) < (1, 4):  # Copy from `std/strutils`
+  #
+  #
+  #            Nim's Runtime Library
+  #        (c) Copyright 2012 Andreas Rumpf
+  #
+  #    See the file "copying.txt", included in this
+  #    distribution, for details about the copyright.
+  #
+  func nimIdentNormalize*(s: string): string =
+    ## Normalizes the string `s` as a Nim identifier.
+    ##
+    ## That means to convert to lower case and remove any '_' on all characters
+    ## except first one.
+    runnableExamples:
+      doAssert nimIdentNormalize("Foo_bar") == "Foobar"
+    result = newString(s.len)
+    if s.len > 0:
+      result[0] = s[0]
+    var j = 1
+    for i in 1..len(s) - 1:
+      if s[i] in {'A'..'Z'}:
+        result[j] = chr(ord(s[i]) + (ord('a') - ord('A')))
+        inc j
+      elif s[i] != '_':
+        result[j] = s[i]
+        inc j
+    if j != s.len: setLen(result, j)
+
+type
+  EnumTestN = enum
+    n1 = "aaa",
+    n2 = "bbb",
+    n3 = "ccc"
+  WrapperTestN = object
+    v: EnumTestN
+EnumTestN.deserializeWithNormalizerInToml(nimIdentNormalize)
+
+type
+  EnumTestO = enum
+    o1,
+    o2,
+    o3
+  WrapperTestO = object
+    v: EnumTestO
+EnumTestO.deserializeWithNormalizerInToml(nimIdentNormalize)
 
 suite "test decoder":
   let rawToml = readFile("tests" / "tomls" / "example.toml")
@@ -241,6 +288,168 @@ suite "test decoder":
     # TODO: this still fails
     #let banana = Toml.decode(toml, CaseObject, "banana")
     #check banana.bananaVal == "Hello Banana"
+
+  test "enums":
+    type
+      EnumTestX = enum
+        x0,
+        x1,
+        x2
+      WrapperX = object
+        v: EnumTestX
+
+      EnumTestY = enum
+        y1 = 1,
+        y3 = 3,
+        y4,
+        y6 = 6
+      WrapperY = object
+        v: EnumTestY
+
+      EnumTestZ = enum
+        z1 = "aaa",
+        z2 = "bbb",
+        z3 = "ccc"
+      WrapperZ = object
+        v: EnumTestZ
+
+    check:
+      Toml.decode("v = 0\n", EnumTestX, "v") == x0
+      Toml.decode("v = 1\n", EnumTestX, "v") == x1
+      Toml.decode("v = 2\n", EnumTestX, "v") == x2
+      Toml.decode("v = \"x0\"\n", EnumTestX, "v") == x0
+      Toml.decode("v = \"x1\"\n", EnumTestX, "v") == x1
+      Toml.decode("v = \"x2\"\n", EnumTestX, "v") == x2
+      Toml.decode("v = \'x0\'\n", EnumTestX, "v") == x0
+      Toml.decode("v = \'x1\'\n", EnumTestX, "v") == x1
+      Toml.decode("v = \'x2\'\n", EnumTestX, "v") == x2
+    expect TomlError:
+      discard Toml.decode("v = 3\n", EnumTestX, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"X0\"\n", EnumTestX, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"X1\"\n", EnumTestX, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"X2\"\n", EnumTestX, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"x_0\"\n", EnumTestX, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"\"\n", EnumTestX, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"0\"\n", EnumTestX, "v")
+
+    check:
+      Toml.decode("v = 1\n", EnumTestY, "v") == y1
+      Toml.decode("v = 3\n", EnumTestY, "v") == y3
+      Toml.decode("v = 4\n", EnumTestY, "v") == y4
+      Toml.decode("v = 6\n", EnumTestY, "v") == y6
+      Toml.decode("v = \"y1\"\n", EnumTestY, "v") == y1
+      Toml.decode("v = \"y3\"\n", EnumTestY, "v") == y3
+      Toml.decode("v = \"y4\"\n", EnumTestY, "v") == y4
+      Toml.decode("v = \"y6\"\n", EnumTestY, "v") == y6
+      Toml.decode("v = \'y1\'\n", EnumTestY, "v") == y1
+      Toml.decode("v = \'y3\'\n", EnumTestY, "v") == y3
+      Toml.decode("v = \'y4\'\n", EnumTestY, "v") == y4
+      Toml.decode("v = \'y6\'\n", EnumTestY, "v") == y6
+    expect TomlError:
+      discard Toml.decode("v = 0\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = 2\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = 5\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = 7\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"Y1\"\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"Y3\"\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"Y4\"\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"Y6\"\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"y_1\"\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"\"\n", EnumTestY, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"1\"\n", EnumTestY, "v")
+
+    check:
+      Toml.decode("v = \"aaa\"\n", EnumTestZ, "v") == z1
+      Toml.decode("v = \"bbb\"\n", EnumTestZ, "v") == z2
+      Toml.decode("v = \"ccc\"\n", EnumTestZ, "v") == z3
+    expect TomlError:
+      discard Toml.decode("v = 0\n", EnumTestZ, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"AAA\"\n", EnumTestZ, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"BBB\"\n", EnumTestZ, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"CCC\"\n", EnumTestZ, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"z1\"\n", EnumTestZ, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"a_a_a\"\n", EnumTestZ, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"\"\n", EnumTestZ, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"\ud83d\udc3c\"\n", EnumTestZ, "v")
+
+    check:
+      Toml.decode("v = \"aaa\"\n", EnumTestN, "v") == n1
+      Toml.decode("v = \"bbb\"\n", EnumTestN, "v") == n2
+      Toml.decode("v = \"ccc\"\n", EnumTestN, "v") == n3
+      Toml.decode("v = \"aAA\"", EnumTestN, "v") == n1
+      Toml.decode("v = \"bBB\"", EnumTestN, "v") == n2
+      Toml.decode("v = \"cCC\"", EnumTestN, "v") == n3
+      Toml.decode("v = \"a_a_a\"", EnumTestN, "v") == n1
+      Toml.decode("v = \"b_b_b\"", EnumTestN, "v") == n2
+      Toml.decode("v = \"c_c_c\"", EnumTestN, "v") == n3
+    expect TomlError:
+      discard Toml.decode("v = 0\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"AAA\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"BBB\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"CCC\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"Aaa\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"Bbb\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"Ccc\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"n1\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"_aaa\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"\"\n", EnumTestN, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"\ud83d\udc3c\"\n", EnumTestN, "v")
+
+    check:
+      Toml.decode("v = 0\n", EnumTestO, "v") == o1
+      Toml.decode("v = 1\n", EnumTestO, "v") == o2
+      Toml.decode("v = 2\n", EnumTestO, "v") == o3
+      Toml.decode("v = \"o1\"\n", EnumTestO, "v") == o1
+      Toml.decode("v = \"o2\"\n", EnumTestO, "v") == o2
+      Toml.decode("v = \"o3\"\n", EnumTestO, "v") == o3
+      Toml.decode("v = \"o_1\"", EnumTestO, "v") == o1
+      Toml.decode("v = \"o_2\"", EnumTestO, "v") == o2
+      Toml.decode("v = \"o_3\"", EnumTestO, "v") == o3
+    expect TomlError:
+      discard Toml.decode("v = \"O1\"\n", EnumTestO, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"O2\"\n", EnumTestO, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"O3\"\n", EnumTestO, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"_o1\"\n", EnumTestO, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"\"\n", EnumTestO, "v")
+    expect TomlError:
+      discard Toml.decode("v = \"\ud83d\udc3c\"\n", EnumTestO, "v")
 
 suite "table array test suite":
   type

--- a/tests/test_decoder.nim
+++ b/tests/test_decoder.nim
@@ -59,35 +59,6 @@ proc readValue(r: var TomlReader, table: var Table[string, int]) =
   parseTable(r, key):
     table[key] = r.parseInt(int)
 
-when (NimMajor, NimMinor) < (1, 4):  # Copy from `std/strutils`
-  #
-  #
-  #            Nim's Runtime Library
-  #        (c) Copyright 2012 Andreas Rumpf
-  #
-  #    See the file "copying.txt", included in this
-  #    distribution, for details about the copyright.
-  #
-  func nimIdentNormalize*(s: string): string =
-    ## Normalizes the string `s` as a Nim identifier.
-    ##
-    ## That means to convert to lower case and remove any '_' on all characters
-    ## except first one.
-    runnableExamples:
-      doAssert nimIdentNormalize("Foo_bar") == "Foobar"
-    result = newString(s.len)
-    if s.len > 0:
-      result[0] = s[0]
-    var j = 1
-    for i in 1..len(s) - 1:
-      if s[i] in {'A'..'Z'}:
-        result[j] = chr(ord(s[i]) + (ord('a') - ord('A')))
-        inc j
-      elif s[i] != '_':
-        result[j] = s[i]
-        inc j
-    if j != s.len: setLen(result, j)
-
 type
   EnumTestN = enum
     n1 = "aaa",

--- a/tests/test_encoder.nim
+++ b/tests/test_encoder.nim
@@ -187,6 +187,53 @@ proc testOptionalField() =
       let u = Toml.decode(w, Vehicle)
       check u == v
 
+proc testEnums() =
+  suite "enum encoder":
+    test "OrdinalEnum":
+      type
+        EnumTest = enum
+          x0,
+          x1,
+          x2
+        Wrapper = object
+          v: EnumTest
+
+      check:
+        Toml.encode(Wrapper(v: x0)) == "v = 0\n"
+        Toml.encode(Wrapper(v: x1)) == "v = 1\n"
+        Toml.encode(Wrapper(v: x2)) == "v = 2\n"
+
+    test "HoleyEnum":
+      type
+        EnumTest = enum
+          y1 = 1,
+          y3 = 3,
+          y4,
+          y6 = 6
+        Wrapper = object
+          v: EnumTest
+
+      check:
+        Toml.encode(Wrapper(v: y1)) == "v = 1\n"
+        Toml.encode(Wrapper(v: y3)) == "v = 3\n"
+        Toml.encode(Wrapper(v: y4)) == "v = 4\n"
+        Toml.encode(Wrapper(v: y6)) == "v = 6\n"
+
+    test "StringEnum":
+      type
+        EnumTest = enum
+          z1 = "aaa",
+          z2 = "bbb",
+          z3 = "ccc"
+        Wrapper = object
+          v: EnumTest
+
+      check:
+        Toml.encode(Wrapper(v: z1)) == "v = \"aaa\"\n"
+        Toml.encode(Wrapper(v: z2)) == "v = \"bbb\"\n"
+        Toml.encode(Wrapper(v: z3)) == "v = \"ccc\"\n"
+
 main()
 testTableArray()
 testOptionalField()
+testEnums()

--- a/tests/test_encoder.nim
+++ b/tests/test_encoder.nim
@@ -199,9 +199,9 @@ proc testEnums() =
           v: EnumTest
 
       check:
-        Toml.encode(Wrapper(v: x0)) == "v = 0\n"
-        Toml.encode(Wrapper(v: x1)) == "v = 1\n"
-        Toml.encode(Wrapper(v: x2)) == "v = 2\n"
+        Toml.encode(Wrapper(v: x0)) == "v = \"x0\"\n"
+        Toml.encode(Wrapper(v: x1)) == "v = \"x1\"\n"
+        Toml.encode(Wrapper(v: x2)) == "v = \"x2\"\n"
 
     test "HoleyEnum":
       type
@@ -214,10 +214,10 @@ proc testEnums() =
           v: EnumTest
 
       check:
-        Toml.encode(Wrapper(v: y1)) == "v = 1\n"
-        Toml.encode(Wrapper(v: y3)) == "v = 3\n"
-        Toml.encode(Wrapper(v: y4)) == "v = 4\n"
-        Toml.encode(Wrapper(v: y6)) == "v = 6\n"
+        Toml.encode(Wrapper(v: y1)) == "v = \"y1\"\n"
+        Toml.encode(Wrapper(v: y3)) == "v = \"y3\"\n"
+        Toml.encode(Wrapper(v: y4)) == "v = \"y4\"\n"
+        Toml.encode(Wrapper(v: y6)) == "v = \"y6\"\n"
 
     test "StringEnum":
       type

--- a/tests/test_features.nim
+++ b/tests/test_features.nim
@@ -62,9 +62,6 @@ type
   HoldTable = object
     data: Table[string, int]
 
-Features.configureTomlDeserialization(
-  allowNumericRepr = true)
-
 proc readValue*(r: var TomlReader, value: var UInt256) =
   var z: string
   let (sign, base) = r.parseNumber(z)
@@ -94,7 +91,7 @@ proc readValue*(r: var TomlReader, value: var HoldInt) =
   value.data = r.parseInt(type value.data)
 
 proc readValue*(r: var TomlReader, value: var HoldEnum) =
-  value.data = r.parseEnum(type value.data)
+  value.data = r.parseEnum(type value.data, allowNumericRepr = true)
 
 proc readValue*(r: var TomlReader, value: var HoldValue) =
   value.data = r.parseValue()
@@ -130,7 +127,7 @@ proc readValue*(r: var TomlReader, value: var HoldSeq) =
 
 proc readValue*(r: var TomlReader, value: var Welder) =
   r.parseList:
-    value.flags.incl r.parseEnum(WelderFlag)
+    value.flags.incl r.parseEnum(WelderFlag, allowNumericRepr = true)
 
 suite "features test suite":
   let rawToml = readFile("tests" / "tomls" / "example.toml")
@@ -343,6 +340,9 @@ type
     fruit1: Fruits
     fruit2: Fruits
     fruit3: Fruits
+
+proc readValue*(r: var TomlReader, value: var Fruits) =
+  value = r.parseEnum(type value, allowNumericRepr = true)
 
 proc writeValue*(w: var TomlWriter, val: Fruits) =
   w.writeValue $val

--- a/tests/test_features.nim
+++ b/tests/test_features.nim
@@ -62,6 +62,9 @@ type
   HoldTable = object
     data: Table[string, int]
 
+HoldEnum.configureTomlDeserialization(
+  allowNumericRepr = true)
+
 proc readValue*(r: var TomlReader, value: var UInt256) =
   var z: string
   let (sign, base) = r.parseNumber(z)

--- a/tests/test_features.nim
+++ b/tests/test_features.nim
@@ -62,7 +62,7 @@ type
   HoldTable = object
     data: Table[string, int]
 
-HoldEnum.configureTomlDeserialization(
+Features.configureTomlDeserialization(
   allowNumericRepr = true)
 
 proc readValue*(r: var TomlReader, value: var UInt256) =

--- a/toml_serialization/reader.nim
+++ b/toml_serialization/reader.nim
@@ -6,8 +6,8 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  tables, strutils, options,
-  stew/[enums, objects], stew/shims/[enumutils, typetraits],
+  enumutils, tables, strutils, typetraits, options,
+  stew/[enums, objects],
   faststreams/inputs, serialization/[object_serialization, errors],
   types, lexer, private/[utils, array_reader]
 

--- a/toml_serialization/writer.nim
+++ b/toml_serialization/writer.nim
@@ -7,6 +7,7 @@
 
 import
   typetraits, options, strutils, tables, unicode,
+  stew/enums,
   faststreams/[outputs, textio], serialization,
   types, private/utils
 
@@ -344,7 +345,11 @@ proc writeValue*(w: var TomlWriter, value: auto) =
     append if value: "true" else: "false"
 
   elif value is enum:
-    w.stream.writeText ord(value)
+    case typeof(value).enumStyle
+    of EnumStyle.Numeric:
+      w.stream.writeText ord(value)
+    of EnumStyle.AssociatedStrings:
+      w.writeValue $value
 
   elif value is range:
     type TVAL = type value

--- a/toml_serialization/writer.nim
+++ b/toml_serialization/writer.nim
@@ -7,7 +7,6 @@
 
 import
   typetraits, options, strutils, tables, unicode,
-  stew/enums,
   faststreams/[outputs, textio], serialization,
   types, private/utils
 
@@ -345,11 +344,7 @@ proc writeValue*(w: var TomlWriter, value: auto) =
     append if value: "true" else: "false"
 
   elif value is enum:
-    case typeof(value).enumStyle
-    of EnumStyle.Numeric:
-      w.stream.writeText ord(value)
-    of EnumStyle.AssociatedStrings:
-      w.writeValue $value
+    w.writeValue $value
 
   elif value is range:
     type TVAL = type value


### PR DESCRIPTION
Currently, we encode enum values always as the numeric value `ord(val)`. unless explicitly overridden using `serializesAsTextInToml` or with a custom `writeValue` implementation. Reduce verbosity by automatically doing that.