### PR TITLE
allow manually triggering CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
To identify regressions with Nim 2.0, it may be useful to manually rerun CI. Add `workflow_dispatch` to allow this.