### PR TITLE
Put array/inline table nonstandard behavior behind flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,14 @@ let res = Toml.encode(z)
 assert res == "fruit1 = \"Apple\"\nfruit2 = \"Banana\"\nfruit3 = \"Orange\"\n"
 ```
 
+You can control the reader behavior when deserializing specific enum using `configureTomlDeserialization`.
+
+``Nim
+configureTomlDeserialization(
+    T: type[enum], allowNumericRepr: static[bool] = false,
+    stringNormalizer: static[proc(s: string): string] = strictNormalize)
+```
+
 ## Helper functions
   - `parseNumber(r: var TomlReader, value: var string): (Sign, NumberBase)`
   - `parseDateTime(r: var TomlReader): TomlDateTime`

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ TOML spec and pass these test suites:
 
 - TOML standard requires time in HH:MM:SS format, `TomlHourMinute` flags will allow HH:MM format.
 
+- TOML standard requires array elements be separated by a comma. Whitespaces are ignored.
+  But due to a bug, the array/inline table elements can be separated by both comma and whitespace.
+  Set `TomlStrictComma` flag on to parse in strict mode, by default the strict mode is off.
+
 ## Keyed mode
 When decoding, only objects, tuples or `TomlValueRef` are allowed at top level.
 All other Nim basic datatypes such as floats, ints, arrays, and booleans must

--- a/tests/test_misc.nim
+++ b/tests/test_misc.nim
@@ -84,32 +84,61 @@ suite "test misc":
     # if it can echo without crash, then it's ok
     check true
 
+  # guarded array comma bug
   test "parseList doubleComma":
     expect TomlError:
-      let t = Toml.decode(arrayDoubleComma, Bools, "bools")
+      let t = Toml.decode(arrayDoubleComma, Bools, "bools", flags = {TomlStrictComma})
       discard t
 
   test "parseList no comma":
     expect TomlError:
-      let t = Toml.decode(arrayNoComma, Bools, "bools")
+      let t = Toml.decode(arrayNoComma, Bools, "bools", flags = {TomlStrictComma})
       discard t
 
   test "parseTable doubleComma":
     expect TomlError:
-      let t = Toml.decode(mapDoubleComma, Maps, "maps")
+      let t = Toml.decode(mapDoubleComma, Maps, "maps", flags = {TomlStrictComma})
       discard t
 
   test "parseTable noComma":
     expect TomlError:
-      let t = Toml.decode(mapNoComma, Maps, "maps")
+      let t = Toml.decode(mapNoComma, Maps, "maps", flags = {TomlStrictComma})
       discard t
 
   test "parseRecord doubleComma":
     expect TomlError:
-      let t = Toml.decode(mapDoubleComma, MapAb)
+      let t = Toml.decode(mapDoubleComma, MapAb, flags = {TomlStrictComma})
       discard t
 
   test "parseRecord noComma":
     expect TomlError:
-      let t = Toml.decode(mapNoComma, MapAb)
+      let t = Toml.decode(mapNoComma, MapAb, flags = {TomlStrictComma})
       discard t
+
+  # exploiting unguarded array comma bug
+  test "TomlStrictComma turned off":
+    let t1 = Toml.decode(arrayDoubleComma, Bools, "bools")
+    check t1 == @[1, 0]
+
+    let t2 = Toml.decode(arrayNoComma, Bools, "bools")
+    check t2 == @[1, 0]
+
+    let t3 = Toml.decode(mapDoubleComma, Maps, "maps")
+    check t3.data[0].id == "a"
+    check t3.data[0].txt == "1"
+    check t3.data[1].id == "b"
+    check t3.data[1].txt == "1"
+
+    let t4 = Toml.decode(mapNoComma, Maps, "maps")
+    check t4.data[0].id == "a"
+    check t4.data[0].txt == "1"
+    check t4.data[1].id == "b"
+    check t4.data[1].txt == "1"
+
+    let t5 = Toml.decode(mapDoubleComma, MapAb)
+    check t5.maps.a == 1
+    check t5.maps.b == 1
+
+    let t6 = Toml.decode(mapNoComma, MapAb)
+    check t6.maps.a == 1
+    check t6.maps.b == 1

--- a/toml_serialization/lexer.nim
+++ b/toml_serialization/lexer.nim
@@ -1551,7 +1551,7 @@ proc parseArray[T](lex: var TomlLexer, value: var T) =
     of EOF:
       raiseTomlErr(lex, errUnterminatedArray)
     of ',':
-      if prevComma:
+      if TomlStrictComma in lex.flags and prevComma:
         raiseTomlErr(lex, errValueExpected)
 
       prevComma = true
@@ -1573,7 +1573,7 @@ proc parseArray[T](lex: var TomlLexer, value: var T) =
         when T is string:
           value.add ','
     else:
-      if numElem >= 1 and not prevComma:
+      if TomlStrictComma in lex.flags and numElem >= 1 and not prevComma:
         raiseTomlErr(lex, errCommaExpected)
 
       prevComma = false
@@ -1608,7 +1608,7 @@ proc parseInlineTable[T](lex: var TomlLexer, value: var T) =
     of EOF:
       raiseTomlErr(lex, errUnterminatedTable)
     of ',':
-      if prevComma:
+      if TomlStrictComma in lex.flags and prevComma:
         raiseTomlErr(lex, errValueExpected)
 
       if numElem == 0:
@@ -1635,7 +1635,7 @@ proc parseInlineTable[T](lex: var TomlLexer, value: var T) =
       else:
         raiseIllegalChar(lex, next)
     else:
-      if numElem >= 1 and not prevComma:
+      if TomlStrictComma in lex.flags and numElem >= 1 and not prevComma:
         raiseTomlErr(lex, errCommaExpected)
 
       prevComma = false

--- a/toml_serialization/reader.nim
+++ b/toml_serialization/reader.nim
@@ -166,7 +166,7 @@ template parseInlineTable(r: var TomlReader, key: untyped, body: untyped) =
     of EOF:
       raiseTomlErr(r.lex, errUnterminatedTable)
     of ',':
-      if prevComma:
+      if TomlStrictComma in r.lex.flags and prevComma:
         raiseTomlErr(r.lex, errValueExpected)
 
       if numElem == 0:
@@ -188,7 +188,7 @@ template parseInlineTable(r: var TomlReader, key: untyped, body: untyped) =
       else:
         raiseIllegalChar(r.lex, next)
     else:
-      if numElem >= 1 and not prevComma:
+      if TomlStrictComma in r.lex.flags and numElem >= 1 and not prevComma:
         raiseTomlErr(r.lex, errCommaExpected)
 
       prevComma = false
@@ -237,7 +237,7 @@ template parseListImpl*(r: var TomlReader, index, body: untyped) =
     of EOF:
       raiseTomlErr(r.lex, errUnterminatedArray)
     of ',':
-      if prevComma:
+      if TomlStrictComma in r.lex.flags and prevComma:
         raiseTomlErr(r.lex, errValueExpected)
 
       prevComma = true
@@ -254,7 +254,7 @@ template parseListImpl*(r: var TomlReader, index, body: untyped) =
         eatChar
         break
     else:
-      if index >= 1 and not prevComma:
+      if TomlStrictComma in r.lex.flags and index >= 1 and not prevComma:
         raiseTomlErr(r.lex, errCommaExpected)
 
       prevComma = false
@@ -416,7 +416,7 @@ proc decodeInlineTable[T](r: var TomlReader, value: var T) =
       of EOF:
         raiseTomlErr(r.lex, errUnterminatedTable)
       of ',':
-        if prevComma:
+        if TomlStrictComma in r.lex.flags and prevComma:
           raiseTomlErr(r.lex, errValueExpected)
 
         if numElem == 0:
@@ -438,7 +438,7 @@ proc decodeInlineTable[T](r: var TomlReader, value: var T) =
         else:
           raiseIllegalChar(r.lex, next)
       else:
-        if numElem >= 1 and not prevComma:
+        if TomlStrictComma in r.lex.flags and numElem >= 1 and not prevComma:
           raiseTomlErr(r.lex, errCommaExpected)
 
         prevComma = false

--- a/toml_serialization/types.nim
+++ b/toml_serialization/types.nim
@@ -49,6 +49,7 @@ type
     TomlHexEscape     # allow \xHH escape sequence
     TomlHourMinute    # allow HH:MM format
     TomlUnknownFields # allow unknow fields
+    TomlStrictComma   # array/inline table elements must be separated by a comma
 
   TomlFlags* = set[TomlFlag]
 


### PR DESCRIPTION
ping @Ivansete-status 

The 'bug' now become a feature of nim-toml-serialization. I've put the strict mode turned off by default, so it should be safe to bump nim-toml-serialization in nim-waku.

The relaxed mode will accepts

```Toml
[elem elem]
[elem, elem]
[elem, , elem]
```