### PR TITLE
Do not close `nil` stream when it failed to open

### DIFF
--- a/toml_serialization.nim
+++ b/toml_serialization.nim
@@ -139,15 +139,14 @@ template tomlLoadImpl*(filename: string,
                        RecordType: distinct type,
                        key: string, tomlCase: TomlCase,
                        params: varargs[untyped]): auto =
-
   mixin init, ReaderType, readValue
   var stream: InputStream
+  when nimvm:
+    let input = staticRead(filename)
+    stream = VMInputStream(pos: 0, data: toVMString(input))
+  else:
+    stream = memFileInput(filename)
   try:
-    when nimvm:
-      let input = staticRead(filename)
-      stream = VMInputStream(pos: 0, data: toVMString(input))
-    else:
-      stream = memFileInput(filename)
     var reader = unpackArgs(init, [TomlReader, stream, params])
     when RecordType is (seq or array) and uTypeIsRecord(RecordType):
       reader.readTableArray(RecordType, key, tomlCase)


### PR DESCRIPTION
When stream fails to open during loading of TOML file, `stream` remains set to `nil`. The `finally` block then triggers SIGSEGV when it tries to close the stream that was never fully opened. Only install the `finally` block once `stream` was initialized to fix this.