### PR TITLE
disable `requiresInit` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        test_lang: [c, cpp]
+        test_lang: [c]
         target:
           - os: linux
             cpu: amd64

--- a/tests/test_decoder.nim
+++ b/tests/test_decoder.nim
@@ -590,11 +590,18 @@ proc readValue(r: var TomlReader, value: var ValidIpAddress) =
 
 suite "optional fields test suite":
   test "optional field with requiresInit pragma":
-    {.warning[UnsafeDefault]:off.} # ValidIpAddress dont have default value
-    var x = Toml.decode("address = '1.2.3.4'", TestObject)
-    check x.address.isSome
-    check x.address.get().value == "1.2.3.4"
-    {.warning[UnsafeDefault]:on.}
+    when true:
+      # Deserialization of `requiresInit` types worked only due to bugs:
+      # https://github.com/status-im/nim-serialization/issues/104
+      # A better solution needs to be found if toml is to support `requiresInit`
+      # types.
+      skip()
+    else:
+      {.warning[UnsafeDefault]:off.} # ValidIpAddress dont have default value
+      var x = Toml.decode("address = '1.2.3.4'", TestObject)
+      check x.address.isSome
+      check x.address.get().value == "1.2.3.4"
+      {.warning[UnsafeDefault]:on.}
 
 type
   KV = object


### PR DESCRIPTION
This worked only due to nim bugs which (hopefully) will be fixed:

https://github.com/nim-lang/Nim/issues/25116
https://github.com/nim-lang/Nim/issues/25117

A more comprehensive rework of nim-ser would be needed to support this:

https://github.com/status-im/nim-serialization/issues/104