### PR TITLE
remove macos-13 from the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
           - os: linux
             cpu: i386
           - os: macos
-            cpu: amd64
-          - os: macos
             cpu: arm64
           - os: windows
             cpu: amd64
@@ -29,10 +27,6 @@ jobs:
           - target:
               os: linux-gcc-14 # This is to use ubuntu 24 and install gcc 14. Should be removed when ubuntu-latest is 26.04
             builder: ubuntu-24.04
-          - target:
-              os: macos
-              cpu: amd64
-            builder: macos-13
           - target:
               os: macos
               cpu: arm64


### PR DESCRIPTION
It is no longer supported, starting from September 1st: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down